### PR TITLE
Update branches in git clone commands

### DIFF
--- a/content/get-started/development-environment.rst
+++ b/content/get-started/development-environment.rst
@@ -11,13 +11,13 @@ First of all a directory must be created in which the modules can be stored. The
 
 .. code-block:: bash
 
-   shell> git clone git@github.com:RotherOSS/otobo.git -b master
+   shell> git clone git@github.com:RotherOSS/otobo.git
 
-For a specific branch like OTOBO 6:
+For a specific branch like OTOBO 10.1:
 
 .. code-block:: bash
 
-   shell> git clone git@github.com:RotherOSS/otobo.git -b rel-6_0
+   shell> git clone git@github.com:RotherOSS/otobo.git -b rel-10_1
 
 Please configure the OTOBO system according to the `installation instructions`_.
 


### PR DESCRIPTION
From `content/get-started/development-environment.rst`:

   shell> git clone git@github.com:RotherOSS/otobo.git -b master
   shell> git clone git@github.com:RotherOSS/otobo.git -b rel-6_0

Both of these branches do not exist anymore:

```
tmp % git clone git@github.com:RotherOSS/otobo.git -b master
Cloning into 'otobo'...
fatal: Remote branch master not found in upstream origin
 % git clone git@github.com:RotherOSS/otobo.git -b rel-6_0
Cloning into 'otobo'...
fatal: Remote branch rel-6_0 not found in upstream origin
```

So I've updated the commands, the first one to clone just the github default and the second one to use the `rel-10_1` branch